### PR TITLE
chore: add support for fetch-creds

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -34,18 +34,18 @@ symlink-config:
 
 test-integration-build:
   @echo "Testing building docker image"
-  docker build -t workbench-test-build -f contrib/docker/full/Dockerfile .
+  docker build --no-cache -t workbench-test-build -f contrib/docker/full/Dockerfile .
   @echo "Build completed successfully!"
 
 test-integration-install:
   @echo "Building and testing install script in Docker..."
-  docker build -t workbench-test-install -f tests/integration/install/ubuntu-2404/Dockerfile.test .
+  docker build --no-cache -t workbench-test-install -f tests/integration/install/ubuntu-2404/Dockerfile.test .
   docker run -t workbench-test-install
   @echo "Install test completed successfully!"
 
 test-integration-dotfiles:
   @echo "Building and testing dotfiles in Docker..."
-  docker build -t workbench-test-dotfiles -f tests/integration/dotfiles/Dockerfile.test .
+  docker build --no-cache -t workbench-test-dotfiles -f tests/integration/dotfiles/Dockerfile.test .
   docker run -t workbench-test-dotfiles
   @echo "Dotfiles test completed successfully!"
 

--- a/dotfiles/bash_aliases
+++ b/dotfiles/bash_aliases
@@ -6,3 +6,6 @@ alias vimdiff='nvim -d'
 # Search aliases
 alias ag='rg'
 alias grep='rg'
+
+# Fabric
+alias fabric='fabric-ai'

--- a/install/ubuntu-2404/install.py
+++ b/install/ubuntu-2404/install.py
@@ -156,12 +156,16 @@ def install_python_tools() -> None:
     """Install Python tools using uv."""
     script_dir = Path(__file__).parent
     tools_file = script_dir / "uv-tool.txt"
+    ssh_dir = Path.home() / ".ssh"
 
     logger.info("Starting Python tool installation via uv...")
     tools = read_packages(str(tools_file))
     if tools:
         logger.info(f"Installing {len(tools)} Python tools:")
         for tool in tools:
+            if tool.startswith("git+ssh://") and not ssh_dir.exists():
+                logger.warning(f"Skipping {tool} as ~/.ssh directory does not exist")
+                continue
             run_command(["uv", "tool", "install", tool])
     else:
         logger.warning("No Python tools found to install")

--- a/install/ubuntu-2404/uv-tool.txt
+++ b/install/ubuntu-2404/uv-tool.txt
@@ -3,3 +3,5 @@ llm
 mypy
 ruff
 ty
+
+git+ssh://git@github.com/mattjmcnaughton/fetch-creds.git


### PR DESCRIPTION
I wrote a simple, private python utility for managing creds. Install it and copy over the config file.

We add a lightweight filter so that we don't try and install private packages when running in CI (or any environment without the proper SSH creds).

Close #4 